### PR TITLE
Apply Debian-stable patch: Fix HPPA build problem for Debian

### DIFF
--- a/Imakefile
+++ b/Imakefile
@@ -5,11 +5,7 @@
 /*
  *  Tell it what extensions to use.
  */
-#ifndef HPArchitecture
 #define HasScreenSaver 1  /* By default assume to have MIT ScreenSaver, */
-#else
-#define HasScreenSaver 0  /* except on HP machines (sigh...)            */
-#endif
 
 #define HasXidle       0  /* By default assume not to have Xidle.       */
 


### PR DESCRIPTION
Source: https://sources.debian.org/patches/xautolock/1:2.2-5.1/13-fix-hppa-build.patch/